### PR TITLE
Propagate AsyncContext for style element events

### DIFF
--- a/source
+++ b/source
@@ -19196,6 +19196,8 @@ console.log(style.disabled); // false</code></pre>
    <code>style</code> element, "<code data-x="">style</code>", and the <code>style</code> element's
    <span>child text content</span>, then return. <ref>CSP</ref></p></li>
 
+   <li><p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p></li>
+
    <li>
     <p><span>Create a CSS style sheet</span> with the following properties:</p>
 
@@ -19258,63 +19260,65 @@ console.log(style.disabled); // false</code></pre>
    <span>matches the environment</span> and <var>element</var> is
    <span>potentially render-blocking</span>, then <span>block rendering</span> on
    <var>element</var>.</p></li>
-  </ol>
-  </div>
-
-  <!-- the following steps are similar to the text in the <link> element's default process the
-  linked resource algorithm -->
-  <div algorithm>
-  <p>Once the attempts to obtain the style sheet's <span>critical subresources</span>, if any, are
-  complete, or, if the style sheet has no <span>critical subresources</span>, once the style sheet
-  has been parsed and processed, the user agent must run these steps:</p>
-
-  <p class="XXX">Fetching the <span>critical subresources</span> is not well-defined; probably <a
-  href="https://github.com/whatwg/html/issues/968">issue #968</a> is the best resolution for that.
-  In the meantime, any <span data-x="critical subresources">critical subresource</span> <span
-  data-x="concept-request">request</span> should have its <span
-  data-x="concept-request-render-blocking">render-blocking</span> set to whether or not the
-  <code>style</code> element is currently <span>render-blocking</span>.</p>
-
-  <ol>
-   <li><p>Let <var>element</var> be the <code>style</code> element associated with the style sheet
-   in question.</p></li>
-
-   <li><p>Let <var>success</var> be true.</p></li>
 
    <li>
-    <p>If the attempts to obtain any of the style sheet's <span>critical subresources</span> failed
-    for any reason (e.g., DNS error, HTTP 404 response, a connection being prematurely closed,
-    unsupported Content-Type), set <var>success</var> to false.</p>
-
-    <p class="note">Note that content-specific errors, e.g., CSS parse errors or PNG decoding
-    errors, do not affect <var>success</var>.</p>
-   </li>
-
-   <li>
-    <p><span>Queue an element task</span> on the <span>networking task source</span> given
-    <var>element</var> and the following steps:</p>
+    <p>Run these steps <span>in parallel</span>:</p>
 
     <ol>
-     <li><p>If <var>success</var> is true, <span data-x="concept-event-fire">fire an event</span>
-     named <code data-x="event-load">load</code> at <var>element</var>.</p></li>
-
-     <li><p>Otherwise, <span data-x="concept-event-fire">fire an event</span> named <code
-     data-x="event-error">error</code> at <var>element</var>.</p></li>
-
+     <!-- the following steps are similar to the text in the <link> element's default process the
+     linked resource algorithm -->
      <li>
-      <p>If <var>element</var> <span>contributes a script-blocking style sheet</span>:</p>
+      <p>Wait until the attempts to obtain the style sheet's <span>critical subresources</span>, if
+      any, are complete, or, if the style sheet has no <span>critical subresources</span>, until the
+      style sheet has been parsed and processed.</p>
 
-      <ol>
-       <li><p><span>Assert</span>: <var>element</var>'s <span>node document</span>'s
-       <span>script-blocking style sheet set</span> <span data-x="list contains">contains</span>
-       <var>element</var>.</p></li>
-
-       <li><p><span data-x="list remove">Remove</span> <var>element</var> from its <span>node
-       document</span>'s <span>script-blocking style sheet set</span>.</p></li>
-      </ol>
+      <p class="XXX">Fetching the <span>critical subresources</span> is not well-defined; probably <a
+      href="https://github.com/whatwg/html/issues/968">issue #968</a> is the best resolution for that.
+      In the meantime, any <span data-x="critical subresources">critical subresource</span> <span
+      data-x="concept-request">request</span> should have its <span
+      data-x="concept-request-render-blocking">render-blocking</span> set to whether or not the
+      <code>style</code> element is currently <span>render-blocking</span>.</p>
      </li>
 
-     <li><p><span>Unblock rendering</span> on <var>element</var>.</p></li>
+     <li><p>Let <var>success</var> be true.</p></li>
+
+     <li>
+      <p>If the attempts to obtain any of the style sheet's <span>critical subresources</span>
+      failed for any reason (e.g., DNS error, HTTP 404 response, a connection being prematurely
+      closed, unsupported Content-Type), set <var>success</var> to false.</p>
+
+      <p class="note">Note that content-specific errors, e.g., CSS parse errors or PNG decoding
+      errors, do not affect <var>success</var>.</p>
+     </li>
+
+     <li>
+      <p><span>Queue an element task</span> on the <span>networking task source</span> given
+      <var>element</var> and the following steps:</p>
+
+      <ol>
+       <li><p>If <var>success</var> is true, <span data-x="concept-event-fire">fire an event</span>
+       named <code data-x="event-load">load</code> at <var>element</var> with
+       <var>acMapping</var>.</p></li>
+
+       <li><p>Otherwise, <span data-x="concept-event-fire">fire an event</span> named <code
+       data-x="event-error">error</code> at <var>element</var> with <var>acMapping</var>.</p></li>
+
+       <li>
+        <p>If <var>element</var> <span>contributes a script-blocking style sheet</span>:</p>
+
+        <ol>
+         <li><p><span>Assert</span>: <var>element</var>'s <span>node document</span>'s
+         <span>script-blocking style sheet set</span> <span data-x="list contains">contains</span>
+         <var>element</var>.</p></li>
+
+         <li><p><span data-x="list remove">Remove</span> <var>element</var> from its <span>node
+         document</span>'s <span>script-blocking style sheet set</span>.</p></li>
+        </ol>
+       </li>
+
+       <li><p><span>Unblock rendering</span> on <var>element</var>.</p></li>
+      </ol>
+     </li>
     </ol>
    </li>
   </ol>


### PR DESCRIPTION
## To test

### Different types of insertion

- [ ] Element created detached with CSS already set and attached through `.append` propagates
  ```js
  const s = document.createElement("style"); s.textContent = "@import url('/a.css');";
  s.onload = () => assert_equals(v.get(), "v");
  v.run("v", () => document.head.append(s));
  ```
- [ ] `innerHTML` / `insertAdjacentHTML` insertion propagates to `load`
- [ ] `document.write` propagates to `load`
- [ ] Mutating the text of an already-connected `<style>` re-runs the algorithm; the insertion context must not be reused.

### Different types of things to laod

- [ ] `load` with no critical subresources (only inline CSS)
- [ ] load` with an uncached `@import`
- [ ] `load` with a cached `@import`: a second `<style>` importing an already-loaded URL must report its *own* context, not the first element's.
- [ ] `load` with a `data:` URL `@import`
- [ ] `error` on a failed critical subresource, e.g. `@import url('/404.css')`.
- [ ] CSS parse errors still fire `load`, with the insertion context.

### No propagation

- [ ] `<style type="text/plain">`, a CSP-blocked inline style, and a `textContent` write on a *disconnected* `<style>` do not fire any event, so no capturing. There isn't actually much to test, maybe something with `WeakRef` to check that the context is GC'ed? But GC is implementation-defined.
- [ ] A `<style>` appended delays the document `load` event, but `window.onload` must still see `undefined` and not the `<style>` insertion context
- [ ] Removal does not retarget a pending event, so `s.remove()` inside `v.run("removed")` does not change the context of in-flight `load`/`error` events that have already been queued (how to test? very racy)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/3/semantics.html" title="Last updated on Aug 14, 2026, 3:25 PM UTC (42605ce)">/semantics.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/3/6265679...42605ce/semantics.html" title="Last updated on Aug 14, 2026, 3:25 PM UTC (42605ce)">diff</a> )