### PR TITLE
Propagate AsyncContext for link element events

### DIFF
--- a/source
+++ b/source
@@ -17109,6 +17109,8 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
   <var>el</var>, is as follows:</p>
 
   <ol>
+   <li><p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p></li>
+
    <li><p>Let <var>options</var> be the result of <span data-x="create link options from
    element">creating link options</span> from <var>el</var>.</p></li>
 
@@ -17164,7 +17166,7 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
      </li>
 
      <li><p><span>Process the linked resource</span> given <var>el</var>, <var>success</var>,
-     <var>response</var>, and <var>bodyBytes</var>.</li>
+     <var>response</var>, <var>bodyBytes</var>, and <var>acMapping</var>.</li>
     </ol>
    </li>
   </ol>
@@ -17230,8 +17232,9 @@ interface <dfn interface>HTMLLinkElement</dfn> : <span>HTMLElement</span> {
   <p>Similar to the <span>fetch and process the linked resource</span> algorithm, all <span
   data-x="external resource link">external resource links</span> have a <dfn>process the linked
   resource</dfn> algorithm which takes a <code>link</code> element <var>el</var>, boolean
-  <var>success</var>, a <span data-x="concept-response">response</span> <var>response</var>, and a
-  <span>byte sequence</span> <var>bodyBytes</var>. Individual link types may provide their own
+  <var>success</var>, a <span data-x="concept-response">response</span> <var>response</var>, a
+  <span>byte sequence</span> <var>bodyBytes</var>, and an <span>Async Context Mapping</span>
+  <var>acMapping</var>. Individual link types may provide their own
   <span>process the linked resource</span> algorithm, but unless explicitly stated, that algorithm
   does nothing.</p>
   </div>
@@ -28913,8 +28916,10 @@ document.body.appendChild(wbr);</code></pre>
   <div algorithm>
   <p>To <span data-x="process the linked resource">process this type of linked resource</span> given
   a <code>link</code> element <var>el</var>, boolean <var>success</var>, <span
-  data-x="concept-response">response</span> <var>response</var>, and <span>byte sequence</span>
-  <var>bodyBytes</var>:</p>
+  data-x="concept-response">response</span> <var>response</var>, <span>byte sequence</span>
+  <var>bodyBytes</var>, and an <span>Async Context Mapping</span> <var>acMapping</var>:</p>
+
+  <p class="note"><var>acMapping</var> is unused by this algorithm, as it fires no events.</p>
 
   <ol>
    <li><p>If <var>response</var>'s <span data-x="Content-Type">Content-Type metadata</span> is not a
@@ -29016,6 +29021,8 @@ document.body.appendChild(wbr);</code></pre>
   <var>el</var>, is as follows:</p>
 
   <ol>
+   <li><p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p></li>
+
    <li><p>If <var>el</var>'s <code data-x="attr-link-href">href</code> attribute's value is the
    empty string, then return.</p></li>
 
@@ -29027,7 +29034,8 @@ document.body.appendChild(wbr);</code></pre>
    <li><p>If <var>destination</var> is not a <span>module preload destination</span>, then
    <span>queue an element task</span> on the <span>networking task source</span> given <var>el</var>
    to <span data-x="concept-event-fire">fire an event</span> named <code
-   data-x="event-error">error</code> at <var>el</var>, and return.</p></li>
+   data-x="event-error">error</code> at <var>el</var> with <var>acMapping</var>, and
+   return.</p></li>
 
    <li><p>Let <var>url</var> be the result of <span>encoding-parsing a URL</span> given
    <var>el</var>'s <code data-x="attr-link-href">href</code> attribute's value, relative to
@@ -29077,11 +29085,11 @@ document.body.appendChild(wbr);</code></pre>
 
     <ol>
      <li><p>If <var>result</var> is null, then <span data-x="concept-event-fire">fire an
-     event</span> named <code data-x="event-error">error</code> at <var>el</var>,
-     and return.</p></li>
+     event</span> named <code data-x="event-error">error</code> at <var>el</var> with
+     <var>acMapping</var>, and return.</p></li>
 
      <li><p><span data-x="concept-event-fire">Fire an event</span> named <code
-     data-x="event-load">load</code> at <var>el</var>.</p></li>
+     data-x="event-load">load</code> at <var>el</var> with <var>acMapping</var>.</p></li>
     </ol>
    </li>
   </ol>
@@ -29391,6 +29399,8 @@ document.body.appendChild(wbr);</code></pre>
   <var>el</var>, is as follows:</p>
 
   <ol>
+   <li><p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p></li>
+
    <li><p>If <var>el</var>'s <code data-x="attr-link-href">href</code> attribute's value is the
    empty string, then return.</p></li>
 
@@ -29413,10 +29423,10 @@ document.body.appendChild(wbr);</code></pre>
     <ol>
      <li><p>If <var>response</var> is a <span>network error</span>, <span
      data-x="concept-event-fire">fire an event</span> named <code
-     data-x="event-error">error</code> at <var>el</var>.</p></li>
+     data-x="event-error">error</code> at <var>el</var> with <var>acMapping</var>.</p></li>
 
      <li><p>Otherwise, <span data-x="concept-event-fire">fire an event</span> named <code
-     data-x="event-load">load</code> at <var>el</var>.</p></li>
+     data-x="event-load">load</code> at <var>el</var> with <var>acMapping</var>.</p></li>
     </ol>
    </li>
 
@@ -29784,6 +29794,8 @@ document.body.appendChild(wbr);</code></pre>
   given a <code>link</code> element <var>el</var>, are:</p>
 
   <ol>
+   <li><p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p></li>
+
    <li><p><span>Update the source set</span> for <var>el</var>.</p></li>
 
    <li><p>Let <var>options</var> be the result of <span
@@ -29807,9 +29819,9 @@ document.body.appendChild(wbr);</code></pre>
      <li>
       <p>If <var>response</var> is a <span>network error</span>, <span
       data-x="concept-event-fire">fire an event</span> named <code
-      data-x="event-error">error</code> at <var>el</var>. Otherwise, <span
-      data-x="concept-event-fire">fire an event</span> named
-      <code data-x="event-load">load</code> at <var>el</var>.</p>
+      data-x="event-error">error</code> at <var>el</var> with <var>acMapping</var>.
+      Otherwise, <span data-x="concept-event-fire">fire an event</span> named
+      <code data-x="event-load">load</code> at <var>el</var> with <var>acMapping</var>.</p>
 
       <p class="XXX">The actual browsers' behavior is different from the spec here, and the
       feasibility of changing the behavior has not yet been investigated. See <a
@@ -29974,8 +29986,8 @@ document.body.appendChild(wbr);</code></pre>
   <div algorithm>
   <p>To <span data-x="process the linked resource">process this type of linked resource</span>
   given a <code>link</code> element <var>el</var>, boolean <var>success</var>, <span
-  data-x="concept-response">response</span> <var>response</var>, and <span>byte sequence</span>
-  <var>bodyBytes</var>:</p>
+  data-x="concept-response">response</span> <var>response</var>, <span>byte sequence</span>
+  <var>bodyBytes</var>, and an <span>Async Context Mapping</span> <var>acMapping</var>:</p>
 
   <!-- note that we can only get this far if we have a browsing context, since if you don't have a
   browsing context (and are active) you can't ever get a result back from "fetch", and thus you
@@ -30084,12 +30096,12 @@ document.body.appendChild(wbr);</code></pre>
      </li>
 
      <li><p><span data-x="concept-event-fire">Fire an event</span> named <code
-     data-x="event-load">load</code> at <var>el</var>.</p></li>
+     data-x="event-load">load</code> at <var>el</var> with <var>acMapping</var>.</p></li>
     </ol>
    </li>
 
    <li><p>Otherwise, <span data-x="concept-event-fire">fire an event</span> named <code
-   data-x="event-error">error</code> at <var>el</var>.</p></li>
+   data-x="event-error">error</code> at <var>el</var> with <var>acMapping</var>.</p></li>
 
    <li>
     <p>If <var>el</var> <span>contributes a script-blocking style sheet</span>:</p>


### PR DESCRIPTION
## To test

### `rel=stylesheet`

- [ ] `href`/`rel` set before insertion, and then the element is inserted: the insertion context is propagated, since it's insertion that triggers the load
  ```js
  const el = document.createElement("link");
  v.run("early", () => { el.rel = "stylesheet"; el.href = "ok.css"; });
  el.onload = () => assert_equals(v.get(), "insert");
  v.run("insert", () => document.head.append(el));
  ```
- [ ] Capture at the DOM mutation: `href`/`rel`/`crossorigin`/`type`/`disabled` set on a connected `<link>` propagates at mutation time, if it causes a re-fetch.
- [ ] basic propagation for `load` with a 200 response
- [ ] `error` on 404, wrong `Content-Type`, and **`error` on a CORS failure propagate
- [ ] `disabled` fires nothing; when removing `disabled` it captures
- [ ] A discarded loading process drops the context, so setting `href` twice if there is one event it has the context from the second mutation.
- [ ] Preloaded urls still use uses the stylesheet element's own context, so if `rel=preload as=style` loads in context A, and then `rel=stylesheet` for the same URL in context B, stylesheet's `load` runs in B.
- [ ] A second `<link>` for an already-loaded URL propagates its own context, and not the one of the first one.

### `rel=modulepreload`

- [ ] Capture on append to the dom
  ```js
  const el = document.createElement("link");
  el.rel = "modulepreload"; el.as = "image"; el.href = "mod.mjs";
  el.onerror = () => assert_equals(v.get(), "v");
  v.run("v", () => document.head.append(el));
  ```
- [ ] Capture at the DOM mutation: `href`/`rel`/`type` set on a connected `<link>` propagates at mutation time, if it causes a re-fetch.
- [ ] `load` on a successful module graph, and **`error` when the graph fails in a deep module (404, parse error, or a failing dependency).
- [ ] A URL already in the module map still reports its own insertion context.
- [ ] Mutating `as`/`crossorigin`/`referrerpolicy` after the fetch does not propagate (no fetch, so no event is fired, so not much to test?)

### `rel=prefetch` / `rel=preload`

- [ ] Capture on append to the dom, capture on dom mutation.
- [ ] `load` fired due to a 404 still propagates, same as `error` fired for CORS or netework error.
- [ ] TODO: `preload`: `load`/`error` carry the mapping — mark tentative.** there is an `XXX` for [issue #1142](https://github.com/whatwg/html/issues/1142), maybe there is something to test.

### Rels that fire no events

- [ ] `icon`, `dns-prefetch`, `preconnect` fire neither `load` nor `error`**, so no propagation, not much to test.
- [ ] `manifest` fires no events, but it uses the *process this type of linked resource* which takes an async context mapping. Not much to test, maybe we can check that engines are not keeping it alive unnecessarily?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/5/links.html" title="Last updated on Aug 14, 2026, 2:01 PM UTC (5dd17c0)">/links.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/5/42605ce...5dd17c0/links.html" title="Last updated on Aug 14, 2026, 2:01 PM UTC (5dd17c0)">diff</a> )
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/5/semantics.html" title="Last updated on Aug 14, 2026, 2:01 PM UTC (5dd17c0)">/semantics.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/5/42605ce...5dd17c0/semantics.html" title="Last updated on Aug 14, 2026, 2:01 PM UTC (5dd17c0)">diff</a> )