### PR TITLE
Propagate AsyncContext for img element events

### DIFF
--- a/source
+++ b/source
@@ -33124,6 +33124,8 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
   events</i> flag set, it must run the following steps:</p>
 
   <ol>
+   <li><p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p></li>
+
    <li>
     <p>If the element's <span>node document</span> is not <span>fully active</span>:</p>
 
@@ -33211,7 +33213,8 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
 
          <li><p>If <i>maybe omit events</i> is not set or <var>previousURL</var> is not equal to
          <var>urlString</var>, then <span data-x="concept-event-fire">fire an event</span> named
-         <code data-x="event-load">load</code> at the <code>img</code> element.</p></li>
+         <code data-x="event-load">load</code> at the <code>img</code> element with
+         <var>acMapping</var>.</p></li>
         </ol>
        </li>
 
@@ -33268,7 +33271,8 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
         </ul>
 
         <p>then <span data-x="concept-event-fire">fire an event</span> named <code
-        data-x="event-error">error</code> at the <code>img</code> element.</p>
+        data-x="event-error">error</code> at the <code>img</code> element with
+        <var>acMapping</var>.</p>
        </li>
       </ol>
      </li>
@@ -33303,7 +33307,8 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
 
        <li><p>If <i>maybe omit events</i> is not set or <var>previousURL</var> is not equal to
        <var>selected source</var>, then <span data-x="concept-event-fire">fire an event</span>
-       named <code data-x="event-error">error</code> at the <code>img</code> element.</p></li>
+       named <code data-x="event-error">error</code> at the <code>img</code> element with
+       <var>acMapping</var>.</p></li>
       </ol>
      </li>
 
@@ -33470,7 +33475,8 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
        <li><p>If <i>maybe omit events</i> is not set or <var>previousURL</var> is not equal to
        <var>urlString</var>, then <span>queue an element task</span> on the <span>DOM manipulation task source</span>
        given the <code>img</code> element to <span data-x="concept-event-fire">fire an event</span>
-       named <code data-x="event-load">load</code> at the <code>img</code> element.</p></li>
+       named <code data-x="event-load">load</code> at the <code>img</code> element with
+       <var>acMapping</var>.</p></li>
       </ol>
       <!--TODO what if the image is broken?
           TODO change state and fire in the same task? -->
@@ -33512,7 +33518,8 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
          <span data-x="img-error">broken</span>.</p></li>
 
          <li><p><span data-x="concept-event-fire">Fire an event</span> named <code
-         data-x="event-error">error</code> at the <code>img</code> element.</p></li>
+         data-x="event-error">error</code> at the <code>img</code> element with
+         <var>acMapping</var>.</p></li>
         </ol>
        </li>
 
@@ -33526,7 +33533,8 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
 
          <li><p>If <i>maybe omit events</i> is not set or <var>previousURL</var> is not equal to
          <var>urlString</var>, then <span data-x="concept-event-fire">fire an event</span> named
-         <code data-x="event-error">error</code> at the <code>img</code> element.</p></li>
+         <code data-x="event-error">error</code> at the <code>img</code> element with
+         <var>acMapping</var>.</p></li>
         </ol>
        </li>
       </ol>
@@ -33564,7 +33572,8 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
 
        <li><p>If <i>maybe omit events</i> is not set or <var>previousURL</var> is not equal to
        <var>urlString</var>, then <span data-x="concept-event-fire">fire an event</span> named
-       <code data-x="event-load">load</code> at the <code>img</code> element.</p></li>
+       <code data-x="event-load">load</code> at the <code>img</code> element with
+       <var>acMapping</var>.</p></li>
       </ol>
      </dd>
 
@@ -33579,7 +33588,7 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
      <var>urlString</var>, <span>queue an element task</span> on the <span>DOM manipulation task
      source</span> given the <code>img</code> element to <span data-x="concept-event-fire">fire an
      event</span> named <code data-x="event-error">error</code> at the <code>img</code>
-     element.</p></dd>
+     element with <var>acMapping</var>.</p></dd>
     </dl>
    </li>
   </ol>
@@ -34373,8 +34382,12 @@ was an English &lt;a href="/wiki/Music_hall">music hall&lt;/a> singer, ...</code
      <li><p><span data-x="prepare an image for presentation">Prepare <var>image request</var> for
      presentation</span> given the <code>img</code> element.</p></li>
 
-     <li><p><span data-x="concept-event-fire">Fire an event</span> named <code
-     data-x="event-load">load</code> at the <code>img</code> element.</p></li>
+     <li>
+      <p><span data-x="concept-event-fire">Fire an event</span> named <code
+      data-x="event-load">load</code> at the <code>img</code> element.</p>
+
+      <p class="note">At this point the current <span>Async Context Mapping</span> is empty.</p>
+     </li>
     </ol>
    </li>
   </ol>


### PR DESCRIPTION
## To confirm

- [ ] That lazy images propagate as if they were eager, and not from what causes the "paused" load to actually happen (similar for iframes, #7)

## To test


### Basic

- [ ] `src` on a connected `img` fires `load` in the mutation's context.
- [ ] Network error / corrupted image / unsupported format fires `error` in the mutation's context.
- [ ] `src=""` (selected source null) and an unparseable URL propagate to `error`
- [ ] Propagation happens even if `img` is not in the DOM, as loading happens regardless. `new Image()` + `.src =` propafates from when `.src` is set
- [ ] Inserting an image re-starts the load, so it propagates context from there (TODO: double check this)
  ```js
  v.run("A", () => { img.src = url; });
  img.onload = () => assert_equals(v.get(), "B");
  v.run("B", () => { document.body.append(img); });
  ```

### `<img>` inside `<picture>`

- [ ] `srcset` mutation propagates
- [ ] `sizes` mutation propagates
- [ ] `<source>` insertion/removal inside `<picture>` propagates to the `img` after it (because they are dom mutations)
- [ ] `<source>` attribute change (`srcset`, `sizes`, `media`, `type`, `width`, `height`) on a preceding `source` are dom mutations so if a `load` is fired on the `img` they propagate

### Cached images

- [ ] `img.src = img.src` re-fires `load` with the new context
- [ ] Even if a fetch does not happen because the image is cached, it propagates the context as if it did
  ```js
  first.onload = () => {
    second.onload = () => assert_equals(v.get(), "v");
    v.run("v", () => { second.src = first.src; });
  };
  ```
- [ ] Cached + `loading=lazy` fires immediately (as if loading was eager) and propagates

### `loading=lazy`

- [ ] Offscreen lazy image scrolled into view reports the DOM-mutation context, not the scroll's. It keeps the context around and behaves consistently regardless of when the browser actually decided to load the image. (The other option, discarded, would have be to fire it in the empty context, like the `scroll` event)
  ```js
  lazyImg.onload = () => assert_equals(v.get(), "mutate");
  v.run("mutate", () => { lazyImg.src = url; });   // far below the viewport
  v.run("scroll", () => { lazyImg.scrollIntoView(); });
  ```
- [ ] `loading=lazy` on an already-visible image, thus with no lazyness happening, also propagates the same
- [ ] `loading` flipped to `eager` from another context still uses the context the original mutation's, because it's not a [relevant mutation](https://html.spec.whatwg.org/#relevant-mutations). 

### "Racy" cases

- [ ] Two `src` assignments in one task: the first one is ignored, and only the second one actually causes the fetch and propagates the context to the `load`/`error` events
- [ ] Reassigning `src` while a fetch is in flight: the pending request is aborted, so no event uses the first context (this will need some orchestration with the server to ensure that we reassign while it's actually in flight and not when it's done but the event was not fired yet)
- [ ] Reassigning `src` inside the `load` handler captures and re-propagates the value to the _next_ `load` that will be fired, even if it happens to be the same context.
- [ ] If there are two handlers for the `load` event, and the first one sets `.src` in a new context, the second handler still runs for the first event with the original propagated context.

### No propagation

- [ ] Reactions to changes in the environment (https://html.spec.whatwg.org/#img-environment-changes) that cause load/error propagate the empty context. Note sure about how to test this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/6/images.html" title="Last updated on Aug 14, 2026, 3:27 PM UTC (a290b6c)">/images.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/6/5dd17c0...a290b6c/images.html" title="Last updated on Aug 14, 2026, 3:27 PM UTC (a290b6c)">diff</a> )