### PR TITLE
Propagate AsyncContext for embed element events

### DIFF
--- a/source
+++ b/source
@@ -36438,13 +36438,21 @@ interface <dfn interface>HTMLEmbedElement</dfn> : <span>HTMLElement</span> {
   remaining <span data-x="concept-embed-active">potentially active</span> has its <code
   data-x="attr-embed-type">src</code> attribute set, changed, or removed or its <code
   data-x="attr-embed-type">type</code> attribute set, changed, or removed, the user agent must
-  <span>queue an element task</span> on the <dfn>embed task source</dfn> given the element
-  to run <span>the <code>embed</code> element setup steps</span> for that element.</p>
+  run the following steps, where <var>element</var> is the <code>embed</code> element:</p>
+
+  <ol>
+   <li><p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p></li>
+
+   <li><p><span>Queue an element task</span> on the <dfn>embed task source</dfn> given
+   <var>element</var> to run <span>the <code>embed</code> element setup steps</span> for
+   <var>element</var> given <var>acMapping</var>.</p></li>
+  </ol>
   </div>
 
   <div algorithm>
   <p><dfn>The <code>embed</code> element setup steps</dfn> for a given <code>embed</code> element
-  <var>element</var> are as follows:</p>
+  <var>element</var> given <span>Async Context Mapping</span> <var>acMapping</var> are
+  as follows:</p>
 
   <ol>
    <li><p>If another <span data-x="concept-task">task</span> has since been queued to run <span>the
@@ -36483,7 +36491,8 @@ interface <dfn interface>HTMLEmbedElement</dfn> : <span>HTMLElement</span> {
 
        <li><p>If <var>response</var> is a <span>network error</span>, then <span
        data-x="concept-event-fire">fire an event</span> named <code
-       data-x="event-load">load</code> at <var>element</var>, and return.</p></li>
+       data-x="event-load">load</code> at <var>element</var> with <var>acMapping</var>, and
+       return.</p></li>
 
        <li><p>Let <var>type</var> be the result of determining the <span
        data-x="concept-embed-type">type of content</span> given <var>element</var> and
@@ -36513,8 +36522,10 @@ interface <dfn interface>HTMLEmbedElement</dfn> : <span>HTMLElement</span> {
             navigable</span> to <var>response</var>'s <span
             data-x="concept-response-url">URL</span> using <var>element</var>'s <span>node
             document</span>, with <i data-x="navigation-response">response</i> set to
-            <var>response</var>, and <i data-x="navigation-hh">historyHandling</i> set to "<code
-            data-x="NavigationHistoryBehavior-replace">replace</code>".</p>
+            <var>response</var>, <i data-x="navigation-hh">historyHandling</i> set to "<code
+            data-x="NavigationHistoryBehavior-replace">replace</code>", and <i
+            data-x="navigation-container-async-context-mapping">containerAsyncContextMapping</i> set
+            to <var>acMapping</var>.</p>
 
             <p class="note"><var>element</var>'s <code data-x="attr-embed-src">src</code> attribute
             does not get updated if the <span>content navigable</span> gets further navigated to


### PR DESCRIPTION
Depends on #7

## Todo

- [ ] The `embed` element could become potentially active due to some rendering operation, but https://html.spec.whatwg.org/multipage/iframe-embed-object.html#concept-embed-active just says "The element is being rendered, or was being rendered the last time the event loop reached step 1.". When is the browser noticing this? Is it guaranteed to notice it with the empty context active? Maybe even just a note is enough.

## To test

### Basic

- [ ] `src` mutation on a potentially-active `embed` propagates.
  ```js
  e.onload = () => assert_equals(v.get(), "v");
  v.run("v", () => { e.src = "/resources/doc.html"; });
  ```
- [ ] `type` mutation propagates.
- [ ] network error fires `load` propagating the context
  ```js
  good.onload = () => assert_equals(v.get(), "v");
  bad.onload  = () => assert_equals(v.get(), "v"); 
  v.run("v", () => { good.src = "/ok.html"; bad.src = "http://127.0.0.1:1/x"; });
  ```
- [ ] Cross-origin and 404-with-a-body propagate like same-origin

### Becoming *potentially active*

Some of the potentially active conditions are due to the event loop (so empty context), other due to sync changes that would propagate.

- [ ] An element with neither `src` nor `type` becomes potentially active the moment `type` is set, and propagates (3rd condition)
  ```js
  e.onload = () => assert_equals(v.get(), "v");       // e has no src/type yet
  v.run("v", () => { e.type = "text/html"; e.src = "/ok.html"; });
  ```
  - [ ] Also test setting the `src` to empty, if it fires something? (4th condition)5
- [ ] Moving it out of a `<video>` element (5th condition), and something for 6th condition.
- [ ] **(see todo above)**: render-driven activation fires the events in the empty mapping
  ```js
  e.onload = () => assert_equals(v.get(), undefined);
  v.run("v", () => { e.style.display = "block"; });   // from display:none, src already set
  ```

### Concurrency

- [ ] Two `src` assignments in one task: the first task returns ("another task has since been queued" check) so there is only one `load` with the context from the second set.
- [ ] A `src` change after the fetch starts, but before response. Same as previous, will need server coordination.
- [ ] Can we test the case where we set `src`, get a response, schedule a task to fire the `load` event, and then set `src` to something else? It should fire two events, with the two contexts.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/8/iframe-embed-object.html" title="Last updated on Aug 14, 2026, 3:43 PM UTC (a790c22)">/iframe-embed-object.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/8/a020110...a790c22/iframe-embed-object.html" title="Last updated on Aug 14, 2026, 3:43 PM UTC (a790c22)">diff</a> )