### PR TITLE
Propagate AsyncContext for object element events

### DIFF
--- a/source
+++ b/source
@@ -36729,14 +36729,28 @@ interface <dfn interface>HTMLObjectElement</dfn> : <span>HTMLElement</span> {
    <li>the element changes from <span>being rendered</span> to not being rendered, or vice versa,
   </ul> <!-- Changing the base URL doesn't trigger this. -->
 
-  <p>...the user agent must <span>queue an element task</span> on the <span>DOM manipulation task
-  source</span> given the <code>object</code> element to run the following steps to (re)determine
-  what the <code>object</code> element represents. This <span data-x="concept-task">task</span>
-  being <span data-x="queue a task">queued</span> or actively running must <span>delay the load
-  event</span> of the element's <span>node document</span>. <!--As described in the algorithm, once
-  the algorithm starts fetching a resource, the fetch is what starts delaying the load event. But to
-  tide us over from when the parser finds the <object> element and the fetching begins, we have to
-  block the load event like this, lest the parse end before this task gets run.--></p>
+  <p>...the user agent must run the following steps:</p>
+
+  <ol>
+   <li><p>Let <var>element</var> be the <code>object</code> element.</p></li>
+
+   <li><p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p></li>
+
+   <li><p><span>Queue an element task</span> on the <span>DOM manipulation task source</span> given
+   <var>element</var> to <span data-x="determine what an object element represents">determine what
+   the <code>object</code> element represents</span> with <var>acMapping</var>. This
+   <span data-x="concept-task">task</span> being <span data-x="queue a task">queued</span> or
+   actively running must <span>delay the load event</span> of the element's <span>node
+   document</span>.</p></li> <!--As described in the algorithm, once the algorithm starts fetching a
+   resource, the fetch is what starts delaying the load event. But to tide us over from when the
+   parser finds the <object> element and the fetching begins, we have to block the load event like
+   this, lest the parse end before this task gets run.-->
+  </ol>
+  </div>
+
+  <div algorithm>
+  <p>To <dfn>determine what an <code>object</code> element represents</dfn> given an <span>Async
+  Context Mapping</span> <var>acMapping</var>, run the following steps:</p>
 
   <ol>
    <li>
@@ -36784,8 +36798,8 @@ interface <dfn interface>HTMLObjectElement</dfn> : <span>HTMLElement</span> {
      document</span>.</p></li>
 
      <li><p>If <var>url</var> is failure, then <span data-x="concept-event-fire">fire an
-     event</span> named <code data-x="event-error">error</code> at the element and jump to the step
-     below labeled <i>fallback</i>.</p></li>
+     event</span> named <code data-x="event-error">error</code> at the element with
+     <var>acMapping</var>, and jump to the step below labeled <i>fallback</i>.</p></li>
 
      <!-- identical for <embed>/<object> -->
      <li><p>Let <var>request</var> be a new <span data-x="concept-request">request</span> whose
@@ -36819,7 +36833,8 @@ interface <dfn interface>HTMLObjectElement</dfn> : <span>HTMLElement</span> {
 
      <li><p>If the load failed (e.g. there was an HTTP 404 error, there was a DNS error), <span
      data-x="concept-event-fire">fire an event</span> named <code data-x="event-error">error</code>
-     at the element, then jump to the step below labeled <i>fallback</i>.</p></li>
+     at the element with <var>acMapping</var>, then jump to the step below labeled
+     <i>fallback</i>.</p></li>
 
      <li id="object-type-detection">
 
@@ -37022,7 +37037,9 @@ interface <dfn interface>HTMLObjectElement</dfn> : <span>HTMLElement</span> {
         <span>navigate</span><!-- DONAV object --> the element's <span>content navigable</span> to
         <var>response</var>'s <span data-x="concept-response-url">URL</span> using the element's
         <span>node document</span>, with <i data-x="navigation-hh">historyHandling</i> set to
-        "<code data-x="NavigationHistoryBehavior-replace">replace</code>".</p>
+        "<code data-x="NavigationHistoryBehavior-replace">replace</code>" and <i
+        data-x="navigation-container-async-context-mapping">containerAsyncContextMapping</i> set to
+        <var>acMapping</var>.</p>
 
         <p class="note">The <code data-x="attr-object-data">data</code> attribute of the
         <code>object</code> element doesn't get updated if the <span>content navigable</span> gets
@@ -37071,7 +37088,7 @@ interface <dfn interface>HTMLObjectElement</dfn> : <span>HTMLElement</span> {
       then once the resource is completely loaded, <span>queue an element task</span> on the
       <span>DOM manipulation task source</span> given the <code>object</code> element to <span
       data-x="concept-event-fire">fire an event</span> named <code data-x="event-load">load</code>
-      at the element.</p>
+      at the element with <var>acMapping</var>.</p>
 
       <p class="note">If the element <em>does</em> represent its <span>content navigable</span>,
       then an analogous task will be queued when the created <code>Document</code> is <span


### PR DESCRIPTION
Depends on #7

## To confirm

- [ ] Figure out whether we are currently accidentally capturing for the render-based trigger conditions, or if we need to hard-code an empty snapshot in some cases.

  `<embed>` has the same problem and the two need to be solved together, see the todo in #8.

## To test


### Basic

- [ ] `data` mutation propagates to `load`
  ```js
  o.onload = () => assert_equals(v.get(), "v");
  v.run("v", () => { o.data = "/resources/doc.html"; });
  ```
- [ ] URL parsing error propagates to `error` (it's queued before fetching)
- [ ] Load failure propagates to `error`, both 404 and network error.
- [ ] `type` mutation propagates (note: when there isn't any of `classid` or `data`)
- [ ] Insertion into the document propagate, via `appendChild` inside
  `v.run`.
  - [ ] Also check insertion+creation via `.innerHTML = "..."`
- [ ] Re-determination caused by rendering does not propagate
  ```js
  o.onload = () => assert_equals(v.get(), undefined);
  v.run("v", () => { o.style.display = "block"; });
  ```

### Races

- [ ] Every navigation re-captures
  ```js
  o.onload = () => { o.onload = () => assert_equals(v.get(), "w");
                     v.run("w", () => { o.data = "/resources/doc.html?2"; }); };
  v.run("v", () => { o.data = "/resources/doc.html?1"; });
  ```
- [ ] If the second navigation starts after that the first completes (i.e. _completely finish loading_ runs) but before that the scheduled event is actually fired, the event of the first load uses the context of the first and the second of the second

### Content navigation

- [ ] Navigating through `object.contentWindow.location` does not propagate the context (like for `<iframe>`s)
- [ ] Maybe also copy some tests from the `<iframe>` plan (#7)

### Fallback

- [ ] Can we test that the context is not kept around forever when showing the fallback content? Probably not.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/9/iframe-embed-object.html" title="Last updated on Aug 14, 2026, 3:32 PM UTC (899ffe3)">/iframe-embed-object.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/9/a790c22...899ffe3/iframe-embed-object.html" title="Last updated on Aug 14, 2026, 3:32 PM UTC (899ffe3)">diff</a> )