### PR TITLE
Propagate AsyncContext for input type=image events

### DIFF
--- a/source
+++ b/source
@@ -54682,6 +54682,8 @@ ldh-str       = &lt; as defined in <a href="https://www.rfc-editor.org/rfc/rfc10
 
    <li><p>If <var>url</var> is failure, then return.</p></li>
 
+   <li><p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p></li>
+
    <li><p>Let <var>request</var> be a new <span data-x="concept-request">request</span> whose <span
    data-x="concept-request-url">URL</span> is <var>url</var>, <span
    data-x="concept-request-client">client</span> is the element's <span>node document</span>'s
@@ -54701,13 +54703,14 @@ ldh-str       = &lt; as defined in <a href="https://www.rfc-editor.org/rfc/rfc10
       data-x="input-img-available">available</i>, <span>queue an element task</span> on the
       <span>user interaction task source</span> given the <code>input</code> element to <span
       data-x="concept-event-fire">fire an event</span> named <code data-x="event-load">load</code>
-      at the <code>input</code> element.</p></li>
+      at the <code>input</code> element with <var>acMapping</var>.</p></li>
 
       <li><p>Otherwise, if the fetching process fails without a response from the remote server, or
       completes but the image is not a valid or supported image, then <span>queue an element
       task</span> on the <span>user interaction task source</span> given the <code>input</code>
       element to <span data-x="concept-event-fire">fire an event</span> named <code
-      data-x="event-error">error</code> on the <code>input</code> element.</p></li>
+      data-x="event-error">error</code> at the <code>input</code> element with
+      <var>acMapping</var>.</p></li>
     </ol>
    </li>
   </ol>


### PR DESCRIPTION
## To confirm

- [ ] This is never loaded on demand, right? If a user agent can it's loaded eagerly, otherwise it's never loaded, because of _unless the user agent cannot support images, or its support for images has been disabled, or the user agent only fetches images on demand, ... run these steps:_ in https://html.spec.whatwg.org/#image-button-state-(type=image)

## To test

### Basic

- [ ] `src` set on a connected `type=image` input propagates to `load`.
  ```js
  i.onload = () => assert_equals(v.get(), "v");
  v.run("v", () => { i.src = "/images/green.png"; });
  ```
- [ ] `error` propagates both for on a 404, a network error, or for a 200 response that cannot be decoded as an image
- [ ] Flipping `type` to `image` with `src` already present propagates
  ```js
  i.type = "text"; i.src = "/images/green.png";
  i.onload = () => assert_equals(v.get(), "v");
  v.run("v", () => { i.type = "image"; });
  ```
- [ ] Setting `.src` to the same value also re-fires and propagates
- [ ] Test with `.innerHTML = "<input type=image src=…>"`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/10/input.html" title="Last updated on Aug 14, 2026, 2:16 PM UTC (1b76b17)">/input.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/10/899ffe3...1b76b17/input.html" title="Last updated on Aug 14, 2026, 2:16 PM UTC (1b76b17)">diff</a> )