### PR TITLE
Propagate AsyncContext for EventSource events

### DIFF
--- a/source
+++ b/source
@@ -3380,6 +3380,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li>The <!--en-GB--><dfn id="activation-behaviour" data-x-href="https://dom.spec.whatwg.org/#eventtarget-activation-behavior">activation behavior</dfn> hook</li>
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#eventtarget-legacy-pre-activation-behavior">legacy-pre-activation behavior</dfn> hook</li>
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#eventtarget-legacy-canceled-activation-behavior">legacy-canceled-activation behavior</dfn> hook</li>
+     <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#eventtarget-clear-asynccontext-for-events">clear AsyncContext for events</dfn> algorithm</li>
      <li>The <dfn data-x="creating an event" data-x-href="https://dom.spec.whatwg.org/#concept-event-create">create an event</dfn> algorithm</li>
      <li>The <dfn data-x="concept-event-fire" data-x-href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</dfn> algorithm</li>
      <li>The <dfn data-x-href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</dfn></li>
@@ -3459,6 +3460,7 @@ a.setAttribute('href', 'https://example.com/'); // change the content attribute 
      <li><dfn data-x-href="https://dom.spec.whatwg.org/#valid-attribute-local-name">valid attribute local name</dfn></li>
      <li><dfn data-x-href="https://dom.spec.whatwg.org/#valid-element-local-name">valid element local name</dfn></li>
      <li><dfn data-x-href="https://dom.spec.whatwg.org/#is-a-global-custom-element-registry">is a global custom element registry</dfn></li>
+     <li>The <dfn data-x="PropagatesAsyncContextToEvents" data-x-href="https://dom.spec.whatwg.org/#extendedattrdef-propagatesasynccontexttoevents"><code>[PropagatesAsyncContextToEvents]</code></dfn> extended attribute</li>
     </ul>
 
     <p>The following features are defined in <cite>UI Events</cite>: <ref>UIEVENTS</ref></p>
@@ -132731,7 +132733,8 @@ source.addEventListener('remove', removeHandler, false);</code></pre>
 
   <h4>The <code>EventSource</code> interface</h4>
 
-  <pre><code class="idl">[Exposed=(Window,Worker)]
+  <pre><code class="idl">[Exposed=(Window,Worker),
+ PropagatesAsyncContextToEvents=("open", "error")]
 interface <dfn interface>EventSource</dfn> : <span>EventTarget</span> {
   <span data-x="dom-EventSource">constructor</span>(USVString url, optional <span>EventSourceInit</span> eventSourceInitDict = {});
 
@@ -132956,10 +132959,20 @@ dictionary <dfn dictionary>EventSourceInit</dfn> {
   <div algorithm>
   <p>The <dfn method for="EventSource"><code data-x="dom-EventSource-close">close()</code></dfn>
   method must abort any instances of the <span data-x="concept-fetch">fetch</span> algorithm started
-  for this <code>EventSource</code> object, and must set the <code
+  for this <code>EventSource</code> object, must set the <code
   data-x="dom-EventSource-readyState">readyState</code> attribute to <code
-  data-x="dom-EventSource-CLOSED">CLOSED</code>.</p> <!-- this also causes all the message events to
-  stop firing, even if they were queued before close() was called -->
+  data-x="dom-EventSource-CLOSED">CLOSED</code>, and must <span data-x="clear AsyncContext for
+  events">clear AsyncContext for events</span> with « "<code data-x="event-open">open</code>",
+  "<code data-x="event-error">error</code>" » given this <code>EventSource</code> object.</p>
+  <!-- this also causes all the message events to stop firing, even if they were queued before
+  close() was called -->
+
+  <p class="note">Clearing AsyncContext for events here is not observable: once the <code
+  data-x="dom-EventSource-readyState">readyState</code> attribute is <code
+  data-x="dom-EventSource-CLOSED">CLOSED</code>, every task queued by <span>announce the
+  connection</span>, <span>reestablish the connection</span> and <span>fail the connection</span>
+  returns without firing anything. It however allows implementations to free the resources captured
+  by the Async Context Mapping even if the <code>EventSource</code> object is kept alive.</p>
   </div>
 
   </div>
@@ -132989,9 +133002,19 @@ dictionary <dfn dictionary>EventSourceInit</dfn> {
   task</span> which, if the <code data-x="dom-EventSource-readyState">readyState</code> attribute is
   set to a value other than <code data-x="dom-EventSource-CLOSED">CLOSED</code>, sets the <code
   data-x="dom-EventSource-readyState">readyState</code> attribute to <code
-  data-x="dom-EventSource-OPEN">OPEN</code> and <span data-x="concept-event-fire">fires an
-  event</span> named <code data-x="event-open">open</code> at the <code>EventSource</code>
-  object.</p>
+  data-x="dom-EventSource-OPEN">OPEN</code>, <span data-x="concept-event-fire">fires an
+  event</span> named <code data-x="event-open">open</code> at the <code>EventSource</code> object,
+  and then <span data-x="clear AsyncContext for events">clears AsyncContext for events</span> with
+  « "<code data-x="event-open">open</code>", "<code data-x="event-error">error</code>" » given the
+  <code>EventSource</code> object.</p>
+
+  <p class="note">Both entries are dropped together, and only once the connection has either opened
+  or <span data-x="fail the connection">failed</span> permanently. So the <code>EventSource</code>
+  constructor's <span>Async Context Mapping</span> reaches the first <code
+  data-x="event-open">open</code> or <code data-x="event-error">error</code> event and no later one:
+  a connection that drops and reconnects does so because of external circumstances, not because of
+  anything the constructor did. It also means the mapping is not kept alive for the lifetime of the
+  <code>EventSource</code> object.</p>
   </div>
 
   <div algorithm>
@@ -133065,8 +133088,11 @@ dictionary <dfn dictionary>EventSourceInit</dfn> {
   task</span> which, if the <code data-x="dom-EventSource-readyState">readyState</code> attribute is
   set to a value other than <code data-x="dom-EventSource-CLOSED">CLOSED</code>, sets the <code
   data-x="dom-EventSource-readyState">readyState</code> attribute to <code
-  data-x="dom-EventSource-CLOSED">CLOSED</code> and <span data-x="concept-event-fire">fires an
-  event</span> named <code data-x="event-error">error</code> at the <code>EventSource</code> object.
+  data-x="dom-EventSource-CLOSED">CLOSED</code>, <span data-x="concept-event-fire">fires an
+  event</span> named <code data-x="event-error">error</code> at the <code>EventSource</code> object,
+  and then <span data-x="clear AsyncContext for events">clears AsyncContext for events</span> with
+  « "<code data-x="event-open">open</code>", "<code data-x="event-error">error</code>" » given the
+  <code>EventSource</code> object.
   <strong>Once the user agent has <span data-x="fail the connection">failed the connection</span>,
   it does <em>not</em> attempt to reconnect.</strong></p>
   </div>


### PR DESCRIPTION
_(I still need to re-review this)_

This uses the machinery introduced by https://github.com/whatwg/dom/pull/1451.

## To confirm

- [ ] I'm not sure if I like the way https://github.com/whatwg/dom/pull/1451 defines `[PropagatesAsyncContextToEvents]`; it makes the HTML part of it very implicit and it's very difficult to tell which events will be fired with the context and which without. Maybe a better approach would be `[CaptureAsyncContext=<name>]` to keep the capturing implicit/automatic, but then making the event firing pass the context _explicitly_.
- [ ] Right now it captures the context on creation for the `open` and `error` events, and then cleans it up once the connection is established so events caused by further server actions (sending a message, or dropping the connection) run in the empty context.

## To test

### Propagation

- [ ] `open` fires in the constructor's context
  ```js
  let es; v.run("v", () => { es = new EventSource("/sse"); });
  es.onopen = () => assert_equals(v.get(), "v");
  ```
- [ ] `error` fires in the constructor's context, for a URL that never connects
- [ ] `error` fires in the empty context, for a URL that connects but for which the server then drops the connection before firing `open`
  - [ ] TODO: What if trying to re-establish the connection then fails again? We keep the context until when we have a succesful `open`, so it should propagate.

### No propagation

- [ ] also and a server that closes the stream
- [ ] `message` fires in the EMPTY context.
  - [ ] Also for named events
- [ ] A second `open` after that the connection was opened runs in the empty context
- [ ] `error` after a `open` is empty
- [ ] 

### Other

- [ ] Write them as `.any.js` to test all envs


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/11/infrastructure.html" title="Last updated on Aug 14, 2026, 3:34 PM UTC (2ce61bc)">/infrastructure.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/11/1b76b17...2ce61bc/infrastructure.html" title="Last updated on Aug 14, 2026, 3:34 PM UTC (2ce61bc)">diff</a> )
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/11/server-sent-events.html" title="Last updated on Aug 14, 2026, 3:34 PM UTC (2ce61bc)">/server-sent-events.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/11/1b76b17...2ce61bc/server-sent-events.html" title="Last updated on Aug 14, 2026, 3:34 PM UTC (2ce61bc)">diff</a> )