### PR TITLE
Propagate AsyncContext for details, dialog, and popover toggle events

### DIFF
--- a/source
+++ b/source
@@ -65648,6 +65648,13 @@ interface <dfn interface>HTMLDetailsElement</dfn> : <span>HTMLElement</span> {
    </li>
 
    <li>
+    <p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p>
+
+    <p class="note">This algorithm runs synchronously with the state change that causes the toggle
+    event.</p>
+   </li>
+
+   <li>
     <p><span>Queue an element task</span> given the <span>DOM manipulation task source</span> and
     <var>element</var> to run the following steps:</p>
 
@@ -65656,7 +65663,7 @@ interface <dfn interface>HTMLDetailsElement</dfn> : <span>HTMLElement</span> {
      data-x="event-toggle">toggle</code> at <var>element</var>, using <code>ToggleEvent</code>, with
      the <code data-x="dom-ToggleEvent-oldState">oldState</code> attribute initialized to
      <var>oldState</var> and the <code data-x="dom-ToggleEvent-newState">newState</code> attribute
-     initialized to <var>newState</var>.</p></li>
+     initialized to <var>newState</var>, and with <var>acMapping</var>.</p></li>
 
      <li><p>Set <var>element</var>'s <span>details toggle task tracker</span> to null.</p></li>
     </ol>
@@ -66996,9 +67003,11 @@ interface <dfn interface>HTMLDialogElement</dfn> : <span>HTMLElement</span> {
     </ol>
    </li>
 
+   <li><p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p></li>
+
    <li><p><span>Queue an element task</span> on the <span>user interaction task source</span> given the
    <var>subject</var> element to <span data-x="concept-event-fire">fire an event</span> named
-   <code data-x="event-close">close</code> at <var>subject</var>.</p></li>
+   <code data-x="event-close">close</code> at <var>subject</var> with <var>acMapping</var>.</p></li>
   </ol>
   </div>
 
@@ -67057,6 +67066,13 @@ interface <dfn interface>HTMLDialogElement</dfn> : <span>HTMLElement</span> {
    </li>
 
    <li>
+    <p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p>
+
+    <p class="note">This algorithm runs synchronously with the state change that causes the toggle
+    event.</p>
+   </li>
+
+   <li>
     <p><span>Queue an element task</span> given the <span>DOM manipulation task source</span> and
     <var>element</var> to run the following steps:</p>
 
@@ -67066,8 +67082,8 @@ interface <dfn interface>HTMLDialogElement</dfn> : <span>HTMLElement</span> {
      the <code data-x="dom-ToggleEvent-oldState">oldState</code> attribute initialized to
      <var>oldState</var>, the <code data-x="dom-ToggleEvent-newState">newState</code> attribute
      initialized to <var>newState</var>, and the <code
-     data-x="dom-ToggleEvent-source">source</code> attribute initialized to
-     <var>source</var>.</p></li>
+     data-x="dom-ToggleEvent-source">source</code> attribute initialized to <var>source</var>, and
+     with <var>acMapping</var>.</p></li>
 
      <li><p>Set <var>element</var>'s <span>dialog toggle task tracker</span> to null.</p></li>
     </ol>
@@ -92445,6 +92461,13 @@ dictionary <dfn dictionary>DragEventInit</dfn> : <span>MouseEventInit</span> {
    </li>
 
    <li>
+    <p>Let <var>acMapping</var> be <span>AsyncContextSnapshot</span>().</p>
+
+    <p class="note">This algorithm runs synchronously with the state change that causes the toggle
+    event.</p>
+   </li>
+
+   <li>
     <p><span>Queue an element task</span> given the <span>DOM manipulation task source</span> and
     <var>element</var> to run the following steps:</p>
 
@@ -92454,8 +92477,8 @@ dictionary <dfn dictionary>DragEventInit</dfn> : <span>MouseEventInit</span> {
      the <code data-x="dom-ToggleEvent-oldState">oldState</code> attribute initialized to
      <var>oldState</var>, the <code data-x="dom-ToggleEvent-newState">newState</code> attribute
      initialized to <var>newState</var>, and the <code
-     data-x="dom-ToggleEvent-source">source</code> attribute initialized to
-     <var>source</var>.</p></li>
+     data-x="dom-ToggleEvent-source">source</code> attribute initialized to <var>source</var>, and
+     with <var>acMapping</var>.</p></li>
 
      <li><p>Set <var>element</var>'s <span>popover toggle task tracker</span> to null.</p></li>
     </ol>


### PR DESCRIPTION
## To confirm

- [ ] When there are multiple e.g. `.open()` calls synchronously or in quick succession, they get coalesced. From the way the coalescing works it naturally happens that the propagated context is the one from the last call. This is probably good? It matches what happens when e.g. you trigger another load on a resource-loading element while one is already in flight.

## To test

### Basic for each of the three details/dialog/popover

- [ ] Basic propagation
  ```js
  const v = new AsyncContext.Variable();
  d.addEventListener("toggle", t.step_func_done(() => assert_equals(v.get(), "v")));
  v.run("v", () => { d.open = true; });
  ```
- [ ] Coalescing: when several toggles land in the same turn, only one event fires, and it must carry the **last** context
  ```js
  d.addEventListener("toggle", t.step_func_done(e => {
    assert_equals(v.get(), "second");
    assert_equals(e.oldState, "closed");
    assert_equals(e.newState, "closed");
  }));
  v.run("first",  () => { d.open = true;  });
  v.run("second", () => { d.open = false; });
  ```
- [ ] Clicking a `<summary>`, pressing Escape on a modal `<dialog>`, light-dismissing a popover all propagate the empty context (TODO: How do we test this? `test_driver`?)

### `dialog`-specific

- [ ] `close()` propagates the same context to both `toggle` and `close`
- [ ] `requestClose()` runs *close the dialog* synchronously, so it propagates the same way.
- [ ] `cancel` and `beforetoggle` are synchronous, and they do not affect the context

### `details`-specific

- [ ] `<details name>` actions propagate to the other elements with the same name, as it's a synchronous dom mutation.
  - [ ] Setting `d1.name` can synchronously remove `d2`'s `open` attribute


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/12/interactive-elements.html" title="Last updated on Aug 14, 2026, 4:24 PM UTC (67ab6c4)">/interactive-elements.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/12/2ce61bc...67ab6c4/interactive-elements.html" title="Last updated on Aug 14, 2026, 4:24 PM UTC (67ab6c4)">diff</a> )
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/12/popover.html" title="Last updated on Aug 14, 2026, 4:24 PM UTC (67ab6c4)">/popover.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/12/2ce61bc...67ab6c4/popover.html" title="Last updated on Aug 14, 2026, 4:24 PM UTC (67ab6c4)">diff</a> )