### PR TITLE
Do not propagate AsyncContext across MessagePort events

### DIFF
--- a/source
+++ b/source
@@ -134276,8 +134276,16 @@ dictionary <dfn dictionary>StructuredSerializeOptions</dfn> {
    <li><p>Disentangle <var>initiatorPort</var> and <var>otherPort</var>, so that they are no longer
    entangled or associated with each other.</p></li>
 
-   <li><p><span data-x="concept-event-fire">Fire an event</span> named <code
-   data-x="event-close">close</code> at <var>otherPort</var>.</p></li>
+   <li>
+    <p><span data-x="concept-event-fire">Fire an event</span> named <code
+    data-x="event-close">close</code> at <var>otherPort</var> with <span>Async Context
+    Mapping</span> « ».</p>
+
+    <p class="note">The mapping is given explicitly because these steps are not queued: they run
+    synchronously with whatever caused the disentangling, and for <code
+    data-x="dom-MessagePort-close">close()</code> that is author code. <var>otherPort</var> did not
+    initiate the close, so the initiator's <span>Async Context Mapping</span> is not its.</p>
+   </li>
   </ol>
 
   <div class="note">


### PR DESCRIPTION
Other than "to confirm" question, this PR might be useless anyway if https://github.com/whatwg/html/issues/12797 gets solved by scheduling a task. I'm still keeping it here for the test plan.

## To confirm

- [ ] Do we want this spec change at all? It makes things consistent with other MessagePort events, but violates the expectation that sync stuff doesn't mess with the context. Probably not? In which case this PR can be discarded, but the tests are still needed.

## To test

### MessagePort `close`

It does not propagate the context in these cases (do the multiplication table):

- MessagePort status
  - [ ] not transferred yet
  - [ ] transferred to another document
- Disentanglement reason
  - [ ] `.close()`
  - [ ] garbage collection (can we test this?)
  - [ ] Document destroyed

### MessagePort `message` / `messageerror`

It does not propagate the context in these cases:

- MessagePort status
  - [ ] not transferred yet
  - [ ] transferred to another document
  - [ ] message sent before starting the port
  - [ ] message sent after starting the port
- [ ] Test the worker internal port (`worker.postMessage`)

### `window.postMessage` `message` / `messageerror`

It does not propagate the context in these cases:
- [ ] same-origin iframe
- [ ] cross-origin iframe
- [ ] on its own window

### `BroadcastChannel` `message` / `messageerror`

It does not propagate the context in these cases:
- [ ] Two channels in one realm
- [ ] Cross-real communication


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/13/web-messaging.html" title="Last updated on Aug 19, 2026, 4:31 PM UTC (6d96f24)">/web-messaging.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/13/67ab6c4...6d96f24/web-messaging.html" title="Last updated on Aug 19, 2026, 4:31 PM UTC (6d96f24)">diff</a> )