### PR TITLE
Propagate AsyncContext for track element events

### DIFF
--- a/source
+++ b/source
@@ -37980,10 +37980,20 @@ interface <dfn interface>HTMLTrackElement</dfn> : <span>HTMLElement</span> {
 
   <p>The element has an associated <dfn>track URL</dfn> (a string), initially the empty string.</p>
 
+  <p>The element has an associated <dfn>track processing Async Context Mapping</dfn> (an
+  <span>Async Context Mapping</span>), initially « ». It is used by <span>start the
+  <code>track</code> processing model</span> to fire the <code
+  data-x="event-track-load">load</code> and <code data-x="event-track-error">error</code>
+  events.</p>
+
   <div algorithm>
   <p>When the element's <code data-x="attr-track-src">src</code> attribute is set, run these steps:
 
   <ol>
+   <li><p>If an occurrence of <span>start the <code>track</code> processing model</span> is running
+   for the element's <span>text track</span> and the element, then set the element's <span>track
+   processing Async Context Mapping</span> to <span>AsyncContextSnapshot</span>().</p></li>
+
    <li><p>Let <var>trackURL</var> be failure.</p></li>
 
    <li><p>Let <var>value</var> be the element's <code data-x="attr-track-src">src</code> attribute
@@ -42879,16 +42889,27 @@ interface <dfn interface>VideoTrack</dfn> {
   algorithm). The steps in that section are marked with &#x231B;.</p>
 
   <ol>
-   <li><p>If another occurrence of this algorithm is already running for this <span>text
-   track</span> and its <code>track</code> element, return, letting that other algorithm
-   take care of this element.</p></li>
-
    <li><p>If the <span>text track</span>'s <span>text track mode</span> is not set to one of <span
    data-x="text track hidden">hidden</span> or <span data-x="text track showing">showing</span>,
    then return.</p></li>
 
    <li><p>If the <span>text track</span>'s <code>track</code> element does not have a <span>media
    element</span> as a parent, return.</p></li>
+
+   <li><p>Set the <code>track</code> element's <span>track processing Async Context Mapping</span>
+   to <span>AsyncContextSnapshot</span>().</p></li>
+
+   <li>
+    <p>If another occurrence of this algorithm is already running for this <span>text
+    track</span> and its <code>track</code> element, return, letting that other algorithm
+    take care of this element.</p>
+
+    <p class="note">The previous step ran even though these steps return here, so the occurrence
+    that is already running fires its <code data-x="event-track-load">load</code> and <code
+    data-x="event-track-error">error</code> events with the <span>Async Context Mapping</span> it
+    set. The most recent action asking for this track owns those events, not whichever one happened
+    to start the fetch.</p>
+   </li>
 
    <li><p>Run the remainder of these steps <span>in parallel</span>, allowing whatever caused these steps to
    run to continue.</p></li>
@@ -42959,7 +42980,8 @@ interface <dfn interface>VideoTrack</dfn> {
     on the <span>DOM manipulation task source</span> given the <span>media element</span> to first
     change the <span>text track readiness state</span> to <span data-x="text track failed to
     load">failed to load</span> and then <span data-x="concept-event-fire">fire an event</span>
-    named <code data-x="event-track-error">error</code> at the <code>track</code> element.</p>
+    named <code data-x="event-track-error">error</code> at the <code>track</code> element with its
+    <span>track processing Async Context Mapping</span>.</p>
     <!-- can't be the media element one, since there might not be a media element by this point -->
 
     <p>If fetching does not fail, but the <!--computed--> type of the resource is not a supported
@@ -42970,14 +42992,16 @@ interface <dfn interface>VideoTrack</dfn> {
     in which the aforementioned problem is found must change the <span>text track readiness
     state</span> to <span data-x="text track failed to load">failed to load</span> and <span
     data-x="concept-event-fire">fire an event</span> named <code
-    data-x="event-track-error">error</code> at the <code>track</code> element.</p>
+    data-x="event-track-error">error</code> at the <code>track</code> element with its <span>track
+    processing Async Context Mapping</span>.</p>
 
     <p>If fetching does not fail, and the file was successfully processed, then the final <span
     data-x="concept-task">task</span> that is <span data-x="queue an element task">queued</span> by
     the <span>networking task source</span>, after it has finished parsing the data, must change the
     <span>text track readiness state</span> to <span data-x="text track loaded">loaded</span>, and
     <span data-x="concept-event-fire">fire an event</span> named <code
-    data-x="event-track-load">load</code> at the <code>track</code> element.</p>
+    data-x="event-track-load">load</code> at the <code>track</code> element with its <span>track
+    processing Async Context Mapping</span>.</p>
 
     <p>If, while fetching is ongoing, either:</p>
 
@@ -42997,8 +43021,9 @@ interface <dfn interface>VideoTrack</dfn> {
     source</span> given the <code>track</code> element that first changes the <span>text track
     readiness state</span> to <span data-x="text track failed to load">failed to load</span> and
     then <span data-x="concept-event-fire">fires an event</span> named <code
-    data-x="event-track-error">error</code> at the <code>track</code> element. <!-- can't be the
-    media element one, since there might not be a media element by this point --></p>
+    data-x="event-track-error">error</code> at the <code>track</code> element with its <span>track
+    processing Async Context Mapping</span>. <!-- can't be the media element one, since there might
+    not be a media element by this point --></p>
    </li>
 
    <li><p>Wait until the <span>text track readiness state</span> is no longer set to <span


### PR DESCRIPTION
This one is a bit awkward. `<track>` elements react to some changes to them by having a continously running loop that listens for changes, so there isn't an obvious place where to capture the context and keep it into a variable. I added a slot to the element itself.

## To confirm

- [ ] When aborting a load due to a URL change, it fires an `error` event in the context that changed the URL rather than in the one that initiated the load, as it's the URL change that actually causes the error.
- [ ] When re-setting `.src` to the _same_ URL, should it recapture? Currently it does, but probably it shouldn't as it doesn't cause a re-load.

## To test

### Capture points

- [ ] Basic propagation, trigger is the mode change
  ```js
  const v = new AsyncContext.Variable();
  track.onload = t.step_func_done(() => assert_equals(v.get(), "v"));
  v.run("v", () => { track.track.mode = "showing"; });
  ```
- [ ] Mode set to showing while detached, and then appended. Propagates context from appending, which is what triggers load.
- [ ] Load on creation: `v.run("v", () => video.innerHTML = '<track default src=…>')`

### Fired events

- [ ] `load` on success, propagates from load start
- [ ] `error` on fetch failure (`src` → 404), propagates from load start
- [ ] `error` on an empty URL (no `src`, `mode` set to `"showing"`), propagates from load start
- [ ] `error` on an unsupported format, propagates from load start
- [ ] `error` on the mid-fetch abort, propagates from what causes the abort

### Overwriting

The cases the slot exists for. A local variable passes everything above and fails everything here.

- [ ] `src` changed while loading: both `error` and the next `load` use the _new_ context
  ```js
  v.run("first", () => { track.track.mode = "showing"; });
  // before it's done loading:
  v.run("second", () => { track.src = "/media/good.vtt"; });
  track.onload = t.step_func_done(() => assert_equals(v.get(), "second"));
  ```
- [ ] Same with changing `mode`, or parent
- [ ] `mode = "disabled"` mid-fetch does not capture a new context (TODO: Can we even test this?)
- [ ] Setting `src` to the value it already has still re-captures (TODO: See "to confirm" above)

<!-- . -->


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/pull/14/media.html" title="Last updated on Aug 25, 2026, 4:04 PM UTC (55f3c4f)">/media.html</a>  ( <a href="https://pr-preview.s3.amazonaws.com/nicolo-ribaudo/html/14/6d96f24...55f3c4f/media.html" title="Last updated on Aug 25, 2026, 4:04 PM UTC (55f3c4f)">diff</a> )